### PR TITLE
added local decorator

### DIFF
--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -325,6 +325,14 @@ class StepDecorator(Decorator):
         """
         pass
 
+    @classmethod
+    def should_attach(cls, step):
+        """
+        Can be used to check if the decorator can be attached to the step or not.
+        returns True by default
+        """
+        return True
+
     def task_pre_step(
         self,
         step_name,
@@ -481,6 +489,11 @@ def _attach_decorators_to_step(step, decospecs):
         deconame = splits[0]
         if deconame not in decos:
             raise UnknownStepDecoratorException(deconame)
+
+        # Skip attaching decorator if should_attach returns False.
+        if not decos[deconame].should_attach(step):
+            continue
+
         # Attach the decorator to step if it doesn't have the decorator
         # already. This means that statically defined decorators are always
         # preferred over runtime decorators.

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -29,6 +29,7 @@ STEP_DECORATORS_DESC = [
     ("resources", ".resources_decorator.ResourcesDecorator"),
     ("batch", ".aws.batch.batch_decorator.BatchDecorator"),
     ("kubernetes", ".kubernetes.kubernetes_decorator.KubernetesDecorator"),
+    ("local", ".local_decorator.LocalDecorator"),
     (
         "argo_workflows_internal",
         ".argo.argo_workflows_decorator.ArgoWorkflowsInternalDecorator",

--- a/metaflow/plugins/aws/batch/batch_decorator.py
+++ b/metaflow/plugins/aws/batch/batch_decorator.py
@@ -234,6 +234,11 @@ class BatchDecorator(StepDecorator):
             if not R.use_r():
                 cli_args.entrypoint[0] = sys.executable
 
+    @classmethod
+    def should_attach(cls, step):
+        # return False if local decorator is attached to the step already.
+        return not any(deco.name == "local" for deco in step.decorators)
+
     def task_pre_step(
         self,
         step_name,

--- a/metaflow/plugins/kubernetes/kubernetes_decorator.py
+++ b/metaflow/plugins/kubernetes/kubernetes_decorator.py
@@ -382,6 +382,11 @@ class KubernetesDecorator(StepDecorator):
             cli_args.command_options["run-time-limit"] = self.run_time_limit
             cli_args.entrypoint[0] = sys.executable
 
+    @classmethod
+    def should_attach(cls, step):
+        # return False if local decorator is attached to the step already.
+        return not any(deco.name == "local" for deco in step.decorators)
+
     def task_pre_step(
         self,
         step_name,

--- a/metaflow/plugins/local_decorator.py
+++ b/metaflow/plugins/local_decorator.py
@@ -1,0 +1,12 @@
+from metaflow.decorators import StepDecorator
+
+
+class LocalDecorator(StepDecorator):
+    """
+    Specifies that the step will run locally.
+
+    The decorator will force the step to run locally even if --with batch or
+    --with kubernetes options are specified.
+    """
+
+    name = "local"


### PR DESCRIPTION
1. added a new decorator: `@local`
2. this will force steps to run locally even when doing `--with batch` and `--with kubernetes` by preventing attachment of batch and kubernetes decorators to the steps which have` @local `attached to them already.